### PR TITLE
Modify pppwn.py is not useful / Add replace '.' in FIRMWAREVERSION (run.sh)

### DIFF
--- a/PPPwn/pppwn.py
+++ b/PPPwn/pppwn.py
@@ -822,9 +822,9 @@ class Exploit():
 def main():
     parser = ArgumentParser('pppwn.py')
     parser.add_argument('--interface', required=True)
-    parser.add_argument('--fw', choices=['900', '1100', '9.00', '11.00'], default='1100')
-    parser.add_argument('--stage1', default='pppwn.bin')
-    parser.add_argument('--stage2', default='stage2_11.00.bin')
+    parser.add_argument('--fw', choices=['900', '1100'], default='1100')
+    parser.add_argument('--stage1', default='stage1.bin')
+    parser.add_argument('--stage2', default='stage2.bin')
     args = parser.parse_args()
 
     #print('[+] PPPwn - PlayStation 4 PPPoE RCE by theflow')
@@ -839,10 +839,6 @@ def main():
     if args.fw == '900':
         offs = OffsetsFirmware_900()
     elif args.fw == '1100':
-        offs = OffsetsFirmware_1100()
-    elif args.fw == '9.00':
-        offs = OffsetsFirmware_900()
-    elif args.fw == '11.00':
         offs = OffsetsFirmware_1100()
         
 

--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -12,6 +12,11 @@ SHUTDOWN=true
 # using a usb to ethernet adapter  [true | false]
 USBETHERNET=false
 
+# name of stage1 BIN"
+STAGE1="stage1"
+
+# name of stage2 BIN"
+STAGE2="stage2"
 
 echo -e "\n\n\033[36m _____  _____  _____                 
 |  __ \\|  __ \\|  __ \\
@@ -34,7 +39,7 @@ fi
 echo -e "\n\033[32mReady for console connection\033[92m\nFirmware:\033[93m $FIRMWAREVERSION\033[92m\nInterface:\033[93m $INTERFACE\033[0m\n"
 while [ true ]
 do
-ret=$(sudo python3 /boot/firmware/PPPwn/pppwn.py --interface=$INTERFACE --fw=$FIRMWAREVERSION --stage1=/boot/firmware/PPPwn/stage1_$FIRMWAREVERSION.bin --stage2=/boot/firmware/PPPwn/stage2_$FIRMWAREVERSION.bin)
+ret=$(sudo python3 /boot/firmware/PPPwn/pppwn.py --interface=$INTERFACE --fw=$FIRMWAREVERSION --stage1=/boot/firmware/PPPwn/$STAGE1.bin --stage2=/boot/firmware/PPPwn/$STAGE2.bin)
 if [ $ret -ge 1 ]
    then
         echo -e "\033[32m\nConsole PPPwned! \033[0m\n"

--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -18,6 +18,9 @@ STAGE1="stage1"
 # name of stage2 BIN"
 STAGE2="stage2"
 
+if [[ $FIRMWAREVERSION == *"."* ]]; then
+  FIRMWAREVERSION=${FIRMWAREVERSION/.}
+fi
 echo -e "\n\n\033[36m _____  _____  _____                 
 |  __ \\|  __ \\|  __ \\
 | |__) | |__) | |__) |_      ___ __

--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -18,6 +18,7 @@ STAGE1="stage1"
 # name of stage2 BIN"
 STAGE2="stage2"
 
+# Remove '.' if exist
 if [[ $FIRMWAREVERSION == *"."* ]]; then
   FIRMWAREVERSION=${FIRMWAREVERSION/.}
 fi

--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -4,7 +4,7 @@
 INTERFACE="eth0" 
 
 # console firmware version [11.00 | 9.00]
-FIRMWAREVERSION="11.00" 
+FIRMWARE_VERSION="11.00" 
 
 # shutdown pi on successful pppwn  [true | false]
 SHUTDOWN=true
@@ -13,15 +13,11 @@ SHUTDOWN=true
 USBETHERNET=false
 
 # name of stage1 BIN"
-STAGE1="stage1"
+STAGE1="stage1_${FIRMWARE_VERSION}"
 
 # name of stage2 BIN"
-STAGE2="stage2"
+STAGE2="stage2_${FIRMWARE_VERSION}"
 
-# Remove '.' if exist
-if [[ $FIRMWAREVERSION == *"."* ]]; then
-  FIRMWAREVERSION=${FIRMWAREVERSION/.}
-fi
 echo -e "\n\n\033[36m _____  _____  _____                 
 |  __ \\|  __ \\|  __ \\
 | |__) | |__) | |__) |_      ___ __
@@ -40,10 +36,10 @@ if [ $USBETHERNET = true ] ; then
 	coproc read -t 5 && wait "$!" || true
 	sudo ip link set $INTERFACE up
 fi
-echo -e "\n\033[32mReady for console connection\033[92m\nFirmware:\033[93m $FIRMWAREVERSION\033[92m\nInterface:\033[93m $INTERFACE\033[0m\n"
+echo -e "\n\033[32mReady for console connection\033[92m\nFirmware:\033[93m $FIRMWARE_VERSION\033[92m\nInterface:\033[93m $INTERFACE\033[0m\n"
 while [ true ]
 do
-ret=$(sudo python3 /boot/firmware/PPPwn/pppwn.py --interface=$INTERFACE --fw=$FIRMWAREVERSION --stage1=/boot/firmware/PPPwn/$STAGE1.bin --stage2=/boot/firmware/PPPwn/$STAGE2.bin)
+ret=$(sudo python3 /boot/firmware/PPPwn/pppwn.py --interface=$INTERFACE --fw=${FIRMWARE_VERSION/.} --stage1=/boot/firmware/PPPwn/$STAGE1.bin --stage2=/boot/firmware/PPPwn/$STAGE2.bin)
 if [ $ret -ge 1 ]
    then
         echo -e "\033[32m\nConsole PPPwned! \033[0m\n"


### PR DESCRIPTION
Modify run.sh to use correctly with pppwn.py
- Add 2 VARS in run.sh :
  STAGE1 & STAGE2 : filename without ext 