### PR TITLE
Expose port 8080 for other apps like ezRemote Client

### DIFF
--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -128,6 +128,7 @@ if [ $ret -ge 1 ]
 			sudo iptables -t nat -I PREROUTING -s 192.168.2.0/24 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
 			sudo iptables -t nat -I PREROUTING -p tcp --dport 2121 -j DNAT --to 192.168.2.2:2121
 			sudo iptables -t nat -I PREROUTING -p tcp --dport 3232 -j DNAT --to 192.168.2.2:3232
+			sudo iptables -t nat -I PREROUTING -p tcp --dport 8080 -j DNAT --to 192.168.2.2:8080
 			sudo iptables -t nat -I PREROUTING -p tcp --dport 9090 -j DNAT --to 192.168.2.2:9090
 			sudo iptables -t nat -I PREROUTING -p tcp --dport 12800 -j DNAT --to 192.168.2.2:12800
 			sudo iptables -t nat -A POSTROUTING -s 192.168.2.0/24 ! -d 192.168.2.0/24 -j MASQUERADE


### PR DESCRIPTION
We expose port 8080 so that it can be used by other applications such as [ezRemote](https://github.com/cy33hc/ps4-ezremote-client), an excellent application to be able to install pkgs from a hard drive located on the network.

ezRemote has a [web interface](https://github.com/cy33hc/ps4-ezremote-client?tab=readme-ov-file#how-to-access-the-web-interface) exposed by default on port 8080 (although it can be modified from the application settings). So we would need an available port to be able to use it.