### PR TITLE
[Needs review] DNS fix 

### DIFF
--- a/PPPwn/index.php
+++ b/PPPwn/index.php
@@ -28,7 +28,7 @@ if (isset($_POST['save'])){
  	exec('sudo iptables -X');
 	exec('sudo sysctl net.ipv4.ip_forward=1');
  	exec('sudo sysctl net.ipv4.conf.all.route_localnet=1');
- 	exec('sudo iptables -t nat -I PREROUTING -s 192.168.2.0/24 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.1:5353');
+ 	exec('sudo iptables -t nat -I PREROUTING -s 192.168.2.0/24 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.1:53');
 	$plst = explode(",",trim($_POST["plist"]));
 	for($i = 0; $i < count($plst); ++$i) {
 	 	exec('sudo iptables -t nat -I PREROUTING -p tcp --dport '.str_replace("-", ":", $plst[$i]).' -j DNAT --to 192.168.2.2:'.str_replace(":", "-", $plst[$i]));

--- a/PPPwn/install.sh
+++ b/PPPwn/install.sh
@@ -11,7 +11,6 @@ expand-hosts
 domain-needed
 server=8.8.8.8
 listen-address=127.0.0.1
-port=5353
 conf-file=/etc/dnsmasq.more.conf' | sudo tee /etc/dnsmasq.conf
 echo 'auth
 lcp-echo-failure 3

--- a/PPPwn/pppoe.sh
+++ b/PPPwn/pppoe.sh
@@ -14,7 +14,7 @@ sudo iptables -F
 sudo iptables -X
 sudo sysctl net.ipv4.ip_forward=1
 sudo sysctl net.ipv4.conf.all.route_localnet=1
-sudo iptables -t nat -I PREROUTING -s 192.168.2.0/24 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
+sudo iptables -t nat -I PREROUTING -s 192.168.2.0/24 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.1:53
 if [ -f /boot/firmware/PPPwn/ports.txt ]; then
 	PORTS=$(sudo cat /boot/firmware/PPPwn/ports.txt | tr "," "\n")
 	for prt in $PORTS


### PR DESCRIPTION
After installing the script my raspberry pi's dns stopped worked. Im not a linux expert but it might be because other system services expect the dns of the pi to be at port 53 and not 5353. 

This fix enabled me to be able to use dns on my pi again (8.8.8.8). It still functions as a dns blocker (i tested the domains that are in the blocked list, they are still unreachable, while google.com was reachable from the ps4)