### PR TITLE
Support RPi CM 4

### DIFF
--- a/PPPwn/run.sh
+++ b/PPPwn/run.sh
@@ -60,6 +60,9 @@ VMUSB=false
 elif [[ $PITYP == *"Raspberry Pi 4"* ]] ;then
 coproc read -t 5 && wait "$!" || true
 CPPBIN="pppwn64"
+elif [[ $PITYP == *"Raspberry Pi Compute Module 4"* ]] ;then
+coproc read -t 5 && wait "$!" || true
+CPPBIN="pppwn64"
 elif [[ $PITYP == *"Raspberry Pi 5"* ]] ;then
 coproc read -t 5 && wait "$!" || true
 CPPBIN="pppwn64"


### PR DESCRIPTION
pppwn11 is incorrectly picked for CM4 which causes console crash at Defeating KASLR